### PR TITLE
Pin quarto version in publish action to 1.4's RC

### DIFF
--- a/.github/workflows/_publish.yml
+++ b/.github/workflows/_publish.yml
@@ -14,8 +14,12 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v2
 
+        # We're pinning the version to 1.4's RC candidate
+        # Remove once released.
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          version: 1.4.545
 
       - name: Install R
         uses: r-lib/actions/setup-r@v2


### PR DESCRIPTION
@PMassicotte The PR select the latest Quarto RC candidate, which allows for the RevealJS presentation to work as it contains an updated copy of `pandoc` fixing a raw issue.

Related to: https://github.com/coatless/quarto-webr/issues/126